### PR TITLE
Add sort function for lists

### DIFF
--- a/filbert.js
+++ b/filbert.js
@@ -3006,27 +3006,40 @@
         {
           value: function(x, reverse) {
             var arr2 = this.slice(0);
-            if(typeof x != 'undefined') {
-              arr2.sort(x);
-              for(var i in this) this[i] = arr2[i];
-              if(reverse)
-                this.reverse();
+            var apply_key = function(a, numerical) {
+              var arr3 = arr2.map(x);
+              // construct a dict that maps the array before and after the map
+              var mapping = {}
+              for(var i in arr3) mapping[arr3[i]] = arr2[i];
+              if(numerical)
+                arr3.sort(function(a, b) { return a - b; });
+              else
+                arr3.sort()
+              for(var i in a) a[i] = mapping[arr3[i]];
             }
-            else {
-              for(var i in this) {
-                if(typeof this[i] !== 'number' || !isFinite(this[i])) {
+            for(var i in this) {
+              if(typeof this[i] !== 'number' || !isFinite(this[i])) {
+                if(typeof x != 'undefined') {
+                  apply_key(this, false);
+                }
+                else {
                   arr2.sort();
                   for (var j in this) this[j] = arr2[j];
-                  if(reverse)
-                    this.reverse();
-                  return;
                 }
+                if(reverse)
+                  this.reverse();
+                return;
               }
+            }
+            if(typeof x != 'undefined') {
+              apply_key(this, true);
+            }
+            else {
               arr2.sort(function(a, b) { return a - b; });
               for(var i in this) this[i] = arr2[i];
-              if(reverse)
-                this.reverse();
             }
+            if(reverse)
+              this.reverse();
           },
           enumerable: false
         });

--- a/test/spec/lists_spec.js
+++ b/test/spec/lists_spec.js
@@ -193,14 +193,24 @@ describe("Lists", function () {
     expect(util.run(code)).toEqual([0, 1, 5, 22, 33, 55, 100]);
   });
 
-  it("[100, 1, 0, 22, 33, 5, 55].sort(reverse=True)", function () {
+  it("[100, 1, 0, 22, 33, 5, 55].sort(mykey)", function () {
     var code = "\n\
     a = [100, 1, 0, 22, 33, 5, 55]\n\
-    def foo(x, y):\n\
-      return x - y\n\
-    a.sort(foo, True)\n\
+    def mykey(x):\n\
+      return -x\n\
+    a.sort(mykey)\n\
     return a";
     expect(util.run(code)).toEqual([100, 55, 33, 22, 5, 1, 0]);
+  });
+
+  it("[100, 1, 0, 22, 33, 5, 55].sort(mykey, True)", function () {
+    var code = "\n\
+    a = [100, 1, 0, 22, 33, 5, 55]\n\
+    def mykey(x):\n\
+      return -x\n\
+    a.sort(mykey, True)\n\
+    return a";
+    expect(util.run(code)).toEqual([0, 1, 5, 22, 33, 55, 100]);
   });
 
   it("['100', '1', '0', '22', '33', '5', '55'].sort()", function () {

--- a/test/spec/runtime_spec.js
+++ b/test/spec/runtime_spec.js
@@ -402,7 +402,8 @@ describe("Runtime library tests", function () {
 
   it("sorted([2, 1])", function () {
     var code = "\
-    return sorted([2, 1])\n\
+    a = [2, 1]\n\
+    return sorted(a)\n\
     ";
     expect(util.run(code)).toEqual([1, 2]);
   });
@@ -411,7 +412,8 @@ describe("Runtime library tests", function () {
     var code = "\
     def cmp(x):\n\
       return -x\n\
-    return sorted([2, 1], cmp)\n\
+    a = [2, 1]\n\
+    return sorted(a, cmp)\n\
     ";
     expect(util.run(code)).toEqual([2, 1]);
   });
@@ -420,7 +422,8 @@ describe("Runtime library tests", function () {
     var code = "\
     def cmp(x):\n\
       return -x\n\
-    return sorted([2, 1], cmp, True)\n\
+    a = [2, 1]\n\
+    return sorted(a, cmp, True)\n\
     ";
     expect(util.run(code)).toEqual([1, 2]);
   });


### PR DESCRIPTION
Added list.sort() method. Checks if the list has numbers and sorts them in ascending order or lexicographically otherwise.
